### PR TITLE
Add automatic lane change module

### DIFF
--- a/Plugins/Map/data.py
+++ b/Plugins/Map/data.py
@@ -71,6 +71,8 @@ route_plan: list[RouteSection] = []
 """The current route plan."""
 route_points: list[Position] = []
 """The current route points."""
+prediction_points: list[Position] = []
+"""Predicted points ahead of the truck."""
 navigation_plan: list = []
 """List of RouteNodes that will drive the truck to the destination."""
 last_length: int = 0
@@ -91,6 +93,8 @@ data_path = os.path.join(os.path.dirname(__file__), "data")
 # MARK: Options
 amount_of_points: int = 50
 """How many points will the map calculate ahead. More points = more overhead moving data."""
+prediction_point_count: int = 100
+"""How many points will be generated for the prediction path."""
 heavy_calculations_this_frame: int = -1
 """How many heavy calculations map has done this frame."""
 allowed_heavy_calculations: int = 500

--- a/Plugins/Map/route/auto_lane_change.py
+++ b/Plugins/Map/route/auto_lane_change.py
@@ -1,0 +1,74 @@
+import Plugins.Map.data as data
+import Plugins.Map.route.prediction as prediction
+import Plugins.Map.utils.math_helpers as math_helpers
+import Plugins.Map.classes as c
+import logging
+
+
+def _get_vehicles() -> list:
+    """Fetch vehicles from Traffic module if available."""
+    vehicles = []
+    try:
+        vehicles = data.plugin.modules.Traffic.run()
+        if vehicles is None:
+            vehicles = []
+    except Exception as e:
+        logging.debug(f"AutoLaneChange: could not fetch vehicles: {e}")
+    return vehicles
+
+
+def _path_is_clear(points: list[c.Position], vehicles: list, radius: float = 5.0) -> bool:
+    """Return True if no vehicle is within radius of any point."""
+    for vehicle in vehicles:
+        for point in points:
+            d = math_helpers.DistanceBetweenPoints(
+                (vehicle.position.x, vehicle.position.z),
+                (point.x, point.z),
+            )
+            if d < radius:
+                return False
+    return True
+
+
+def PerformLaneChange():
+    """Automatically perform lane changes based on predicted path."""
+    if len(data.route_plan) < 2:
+        return
+
+    current = data.route_plan[0]
+    next_section = data.route_plan[1]
+
+    if current.is_lane_changing or type(current.items[0].item) != c.Road:
+        return
+
+    if next_section.lane_index == current.lane_index:
+        return
+
+    next_point = next_section.get_points()[0]
+    distance_to_next = math_helpers.DistanceBetweenPoints(
+        (data.truck_x, data.truck_z), (next_point.x, next_point.z)
+    )
+
+    planned_distance = current.get_planned_lane_change_distance()
+    if distance_to_next > planned_distance + 20:
+        return
+
+    points = prediction.GetPredictedPath()[:20]
+    vehicles = _get_vehicles()
+    if not _path_is_clear(points, vehicles):
+        logging.info("AutoLaneChange: traffic detected, slowing down")
+        try:
+            data.controller.aforward = 0.0
+            data.controller.abackward = 1.0
+        except Exception as e:
+            logging.debug(f"AutoLaneChange: failed to brake - {e}")
+        return
+
+    logging.info(
+        f"AutoLaneChange: changing lane {current.lane_index} -> {next_section.lane_index}"
+    )
+    current.force_lane_change = True
+    current.lane_index = next_section.lane_index
+    current.force_lane_change = False
+    data.route_plan = [current] + data.route_plan[1:]
+

--- a/Plugins/Map/route/prediction.py
+++ b/Plugins/Map/route/prediction.py
@@ -1,0 +1,34 @@
+import Plugins.Map.utils.math_helpers as math_helpers
+import Plugins.Map.route.driving as driving
+import Plugins.Map.data as data
+import Plugins.Map.classes as c
+
+
+def GetPredictedPath(point_count: int | None = None) -> list[c.Position]:
+    """Generate future path points based on the current route plan."""
+    if point_count is None:
+        point_count = data.prediction_point_count
+
+    if len(data.route_plan) == 0:
+        data.prediction_points = []
+        return []
+
+    points: list[c.Position] = []
+    for section in data.route_plan:
+        if len(points) > point_count:
+            break
+        if section is None:
+            continue
+        section_points = section.get_points()
+        for point in section_points:
+            if len(points) > point_count:
+                break
+            if len(points) == 0:
+                points.append(point)
+                continue
+            distance = math_helpers.DistanceBetweenPoints(point.tuple(), points[-1].tuple())
+            if distance >= driving.GetPointDistance(len(points), point_count):
+                if distance <= 20 and point not in points:
+                    points.append(point)
+    data.prediction_points = points
+    return points

--- a/Plugins/Map/ui.py
+++ b/Plugins/Map/ui.py
@@ -106,6 +106,7 @@ class SettingsMenu(ETS2LASettingsMenu):
                                 Space(0)
                                 Description(f"Is steering: {self.get_value_from_data('calculate_steering')}")
                                 Description(f"Route points: {len(self.get_value_from_data('route_points'))}")
+                                Description(f"Prediction points: {len(self.get_value_from_data('prediction_points'))}")
                                 Description(f"Route plan elements: {len(self.get_value_from_data('route_plan'))}")
                                 Description(f"Routing mode: {settings.Get('Map', 'RoutingMode')}")
                                 Description(f"Navigation points: {len(self.get_value_from_data('navigation_points'))}")

--- a/Plugins/VisualizationSockets/main.py
+++ b/Plugins/VisualizationSockets/main.py
@@ -430,6 +430,8 @@ class Plugin(ETS2LAPlugin):
     
     def steering(self, data):
         points = self.plugins.Map
+        prediction = self.globals.tags.predicted_path
+        prediction = self.globals.tags.merge(prediction)
         information = self.globals.tags.route_information
         information = self.globals.tags.merge(information)
         
@@ -439,9 +441,10 @@ class Plugin(ETS2LAPlugin):
         if not points:
             return {
                 "points": [],
+                "prediction": [],
                 "information": information
             }
-        
+
         send = {
             "points": [
                 {
@@ -449,6 +452,13 @@ class Plugin(ETS2LAPlugin):
                     "y": point[1],
                     "z": point[2]
                 } for point in points
+            ],
+            "prediction": [
+                {
+                    "x": point[0],
+                    "y": point[1],
+                    "z": point[2]
+                } for point in prediction
             ],
             "information": information # already a dictionary
         }


### PR DESCRIPTION
## Summary
- implement auto lane changing based on predicted path
- reload auto lane change module when changed
- call new functionality each frame and slow down if traffic blocks lane change

## Testing
- `python -m py_compile Plugins/Map/route/auto_lane_change.py Plugins/Map/main.py Plugins/Map/route/prediction.py Plugins/Map/ui.py Plugins/VisualizationSockets/main.py Plugins/Map/route/driving.py Plugins/Map/route/planning.py Plugins/Map/classes.py Plugins/Map/data.py`
