### PR TITLE
Add automatic lane change logic

### DIFF
--- a/Plugins/Map/data.py
+++ b/Plugins/Map/data.py
@@ -71,6 +71,8 @@ route_plan: list[RouteSection] = []
 """The current route plan."""
 route_points: list[Position] = []
 """The current route points."""
+prediction_points: list[Position] = []
+"""Predicted points ahead of the truck."""
 navigation_plan: list = []
 """List of RouteNodes that will drive the truck to the destination."""
 last_length: int = 0
@@ -91,6 +93,8 @@ data_path = os.path.join(os.path.dirname(__file__), "data")
 # MARK: Options
 amount_of_points: int = 50
 """How many points will the map calculate ahead. More points = more overhead moving data."""
+prediction_point_count: int = 100
+"""How many points will be generated for the prediction path."""
 heavy_calculations_this_frame: int = -1
 """How many heavy calculations map has done this frame."""
 allowed_heavy_calculations: int = 500

--- a/Plugins/Map/main.py
+++ b/Plugins/Map/main.py
@@ -26,13 +26,17 @@ import time
 navigation = importlib.import_module("Plugins.Map.navigation.navigation")
 planning = importlib.import_module("Plugins.Map.route.planning")
 driving = importlib.import_module("Plugins.Map.route.driving")
+prediction = importlib.import_module("Plugins.Map.route.prediction")
+auto_lane_change = importlib.import_module("Plugins.Map.route.auto_lane_change")
 im = importlib.import_module("Plugins.Map.utils.internal_map")
-oh = importlib.import_module("Plugins.Map.utils.offset_handler")  
+oh = importlib.import_module("Plugins.Map.utils.offset_handler")
 last_plan_hash = hash(open(planning.__file__).read())
 last_drive_hash = hash(open(driving.__file__).read())
 last_nav_hash = hash(open(navigation.__file__).read())
+last_pred_hash = hash(open(prediction.__file__).read())
+last_auto_lane_hash = hash(open(auto_lane_change.__file__).read())
 last_im_hash = hash(open(im.__file__).read())
-last_oh_hash = hash(open(oh.__file__, encoding="utf-8").read())  
+last_oh_hash = hash(open(oh.__file__, encoding="utf-8").read())
 
 updating_offset_config = False
 
@@ -139,7 +143,7 @@ class Plugin(ETS2LAPlugin):
         self.settings.downloaded_data = ""
 
     def CheckHashes(self):
-        global last_nav_hash, last_drive_hash, last_plan_hash, last_im_hash, last_oh_hash
+        global last_nav_hash, last_drive_hash, last_plan_hash, last_im_hash, last_oh_hash, last_pred_hash, last_auto_lane_hash
         logging.info("Starting navigation module file monitor")
         while True:
             try:
@@ -147,7 +151,9 @@ class Plugin(ETS2LAPlugin):
                 new_drive_hash = hash(open(driving.__file__, encoding='utf-8').read())
                 new_plan_hash = hash(open(planning.__file__, encoding='utf-8').read())
                 new_im_hash = hash(open(im.__file__, encoding='utf-8').read())
-                new_oh_hash = hash(open(oh.__file__, encoding='utf-8').read())  
+                new_oh_hash = hash(open(oh.__file__, encoding='utf-8').read())
+                new_pred_hash = hash(open(prediction.__file__, encoding='utf-8').read())
+                new_auto_lane_hash = hash(open(auto_lane_change.__file__, encoding='utf-8').read())
                 if new_nav_hash != last_nav_hash:
                     last_nav_hash = new_nav_hash
                     logging.info("Navigation module changed, reloading...")
@@ -178,6 +184,17 @@ class Plugin(ETS2LAPlugin):
                     logging.info("Offset handler module changed, reloading...")
                     importlib.reload(oh)
                     logging.info("Successfully reloaded offset handler module")
+                if new_pred_hash != last_pred_hash:
+                    last_pred_hash = new_pred_hash
+                    logging.info("Prediction module changed, reloading...")
+                    importlib.reload(prediction)
+                    logging.info("Successfully reloaded prediction module")
+                if new_auto_lane_hash != last_auto_lane_hash:
+                    last_auto_lane_hash = new_auto_lane_hash
+                    logging.info("Auto lane change module changed, reloading...")
+                    importlib.reload(auto_lane_change)
+                    auto_lane_change.init(self)
+                    logging.info("Successfully reloaded auto lane change module")
             except Exception as e:
                 logging.error(f"Error monitoring modules: {e}")
             time.sleep(1)
@@ -234,6 +251,8 @@ class Plugin(ETS2LAPlugin):
             self.globals.tags.status = {"Map": data.enabled}
             self.settings_menu = SettingsMenu()
             self.settings_menu.plugin = self
+
+            auto_lane_change.init(self)
             
             if self.settings.downloaded_data is None:
                 self.settings.downloaded_data = ""
@@ -308,6 +327,8 @@ class Plugin(ETS2LAPlugin):
                 
                 steering_start_time = time.perf_counter()
                 steering_value = driving.GetSteering()
+                prediction.GetPredictedPath()
+                auto_lane_change.PerformLaneChange()
 
                 if steering_value is not None:
                     steering_value = steering_value / 180
@@ -365,9 +386,11 @@ class Plugin(ETS2LAPlugin):
                     self.globals.tags.road_type = "normal"
 
                 self.globals.tags.route_information = [item.information_json() for item in data.route_plan]
+                self.globals.tags.predicted_path = [point.tuple() for point in data.prediction_points]
             else:
                 self.globals.tags.next_intersection_distance = 1
                 self.globals.tags.road_type = "none"
+                self.globals.tags.predicted_path = []
         except:
             pass
         external_data_time = time.perf_counter() - external_data_start_time

--- a/Plugins/Map/route/auto_lane_change.py
+++ b/Plugins/Map/route/auto_lane_change.py
@@ -1,0 +1,59 @@
+import logging
+import Plugins.Map.data as data
+import Plugins.Map.utils.math_helpers as mh
+import Plugins.Map.route.planning as planning
+
+plugin = None
+traffic_module = None
+
+def init(plugin_obj):
+    """Initialize auto lane change module with plugin reference."""
+    global plugin, traffic_module
+    plugin = plugin_obj
+    try:
+        traffic_module = plugin.modules.Traffic
+    except Exception as e:
+        logging.error(f"Auto lane change failed to get Traffic module: {e}")
+        traffic_module = None
+
+
+def _vehicle_on_path(vehicle, path, threshold=4.0):
+    for point in path:
+        if mh.DistanceBetweenPoints((vehicle.position.x, vehicle.position.z), (point.x, point.z)) < threshold:
+            return True
+    return False
+
+
+def PerformLaneChange():
+    """Automatically perform lane changes ahead of intersections."""
+    if plugin is None or traffic_module is None:
+        return
+
+    if len(data.route_plan) < 2:
+        return
+
+    current = data.route_plan[0]
+    upcoming = data.route_plan[1]
+
+    if current.lane_index == upcoming.lane_index:
+        return
+
+    next_point = upcoming.get_points()[0]
+    dist = mh.DistanceBetweenPoints((data.truck_x, data.truck_z), (next_point.x, next_point.z))
+    if dist > 100:
+        return
+
+    vehicles = traffic_module.run() or []
+    path = data.prediction_points[:20]
+    for vehicle in vehicles:
+        if _vehicle_on_path(vehicle, path):
+            logging.info("Auto lane change: vehicle detected, waiting for gap")
+            plugin.globals.tags.lane_change_status = "waiting_for_gap"
+            return
+
+    logging.info(f"Auto lane change from {current.lane_index} to {upcoming.lane_index}")
+    plugin.globals.tags.lane_change_status = "auto_executing"
+    current.force_lane_change = True
+    current.lane_index = upcoming.lane_index
+    current.force_lane_change = False
+    data.route_plan = [current]

--- a/Plugins/Map/route/prediction.py
+++ b/Plugins/Map/route/prediction.py
@@ -1,0 +1,34 @@
+import Plugins.Map.utils.math_helpers as math_helpers
+import Plugins.Map.route.driving as driving
+import Plugins.Map.data as data
+import Plugins.Map.classes as c
+
+
+def GetPredictedPath(point_count: int | None = None) -> list[c.Position]:
+    """Generate future path points based on the current route plan."""
+    if point_count is None:
+        point_count = data.prediction_point_count
+
+    if len(data.route_plan) == 0:
+        data.prediction_points = []
+        return []
+
+    points: list[c.Position] = []
+    for section in data.route_plan:
+        if len(points) > point_count:
+            break
+        if section is None:
+            continue
+        section_points = section.get_points()
+        for point in section_points:
+            if len(points) > point_count:
+                break
+            if len(points) == 0:
+                points.append(point)
+                continue
+            distance = math_helpers.DistanceBetweenPoints(point.tuple(), points[-1].tuple())
+            if distance >= driving.GetPointDistance(len(points), point_count):
+                if distance <= 20 and point not in points:
+                    points.append(point)
+    data.prediction_points = points
+    return points

--- a/Plugins/Map/ui.py
+++ b/Plugins/Map/ui.py
@@ -106,6 +106,7 @@ class SettingsMenu(ETS2LASettingsMenu):
                                 Space(0)
                                 Description(f"Is steering: {self.get_value_from_data('calculate_steering')}")
                                 Description(f"Route points: {len(self.get_value_from_data('route_points'))}")
+                                Description(f"Prediction points: {len(self.get_value_from_data('prediction_points'))}")
                                 Description(f"Route plan elements: {len(self.get_value_from_data('route_plan'))}")
                                 Description(f"Routing mode: {settings.Get('Map', 'RoutingMode')}")
                                 Description(f"Navigation points: {len(self.get_value_from_data('navigation_points'))}")

--- a/Plugins/VisualizationSockets/main.py
+++ b/Plugins/VisualizationSockets/main.py
@@ -430,6 +430,8 @@ class Plugin(ETS2LAPlugin):
     
     def steering(self, data):
         points = self.plugins.Map
+        prediction = self.globals.tags.predicted_path
+        prediction = self.globals.tags.merge(prediction)
         information = self.globals.tags.route_information
         information = self.globals.tags.merge(information)
         
@@ -439,9 +441,10 @@ class Plugin(ETS2LAPlugin):
         if not points:
             return {
                 "points": [],
+                "prediction": [],
                 "information": information
             }
-        
+
         send = {
             "points": [
                 {
@@ -449,6 +452,13 @@ class Plugin(ETS2LAPlugin):
                     "y": point[1],
                     "z": point[2]
                 } for point in points
+            ],
+            "prediction": [
+                {
+                    "x": point[0],
+                    "y": point[1],
+                    "z": point[2]
+                } for point in prediction
             ],
             "information": information # already a dictionary
         }


### PR DESCRIPTION
## Summary
- introduce `auto_lane_change` module for predicted lane changes
- reload auto lane change module when modified
- initialize and invoke lane change logic each frame

## Testing
- `python -m py_compile Plugins/Map/route/auto_lane_change.py`
- `python -m py_compile Plugins/Map/main.py Plugins/VisualizationSockets/main.py Plugins/Map/ui.py`
- `python -m py_compile Plugins/Map/route/driving.py Plugins/Map/route/planning.py Plugins/Map/classes.py Plugins/Map/data.py`
