### PR TITLE
Add prediction path to Map plugin

### DIFF
--- a/Plugins/Map/data.py
+++ b/Plugins/Map/data.py
@@ -71,6 +71,8 @@ route_plan: list[RouteSection] = []
 """The current route plan."""
 route_points: list[Position] = []
 """The current route points."""
+prediction_points: list[Position] = []
+"""Predicted points ahead of the truck."""
 navigation_plan: list = []
 """List of RouteNodes that will drive the truck to the destination."""
 last_length: int = 0
@@ -91,6 +93,8 @@ data_path = os.path.join(os.path.dirname(__file__), "data")
 # MARK: Options
 amount_of_points: int = 50
 """How many points will the map calculate ahead. More points = more overhead moving data."""
+prediction_point_count: int = 100
+"""How many points will be generated for the prediction path."""
 heavy_calculations_this_frame: int = -1
 """How many heavy calculations map has done this frame."""
 allowed_heavy_calculations: int = 500

--- a/Plugins/Map/main.py
+++ b/Plugins/Map/main.py
@@ -26,13 +26,15 @@ import time
 navigation = importlib.import_module("Plugins.Map.navigation.navigation")
 planning = importlib.import_module("Plugins.Map.route.planning")
 driving = importlib.import_module("Plugins.Map.route.driving")
+prediction = importlib.import_module("Plugins.Map.route.prediction")
 im = importlib.import_module("Plugins.Map.utils.internal_map")
-oh = importlib.import_module("Plugins.Map.utils.offset_handler")  
+oh = importlib.import_module("Plugins.Map.utils.offset_handler")
 last_plan_hash = hash(open(planning.__file__).read())
 last_drive_hash = hash(open(driving.__file__).read())
 last_nav_hash = hash(open(navigation.__file__).read())
+last_pred_hash = hash(open(prediction.__file__).read())
 last_im_hash = hash(open(im.__file__).read())
-last_oh_hash = hash(open(oh.__file__, encoding="utf-8").read())  
+last_oh_hash = hash(open(oh.__file__, encoding="utf-8").read())
 
 updating_offset_config = False
 
@@ -139,7 +141,7 @@ class Plugin(ETS2LAPlugin):
         self.settings.downloaded_data = ""
 
     def CheckHashes(self):
-        global last_nav_hash, last_drive_hash, last_plan_hash, last_im_hash, last_oh_hash
+        global last_nav_hash, last_drive_hash, last_plan_hash, last_im_hash, last_oh_hash, last_pred_hash
         logging.info("Starting navigation module file monitor")
         while True:
             try:
@@ -147,7 +149,8 @@ class Plugin(ETS2LAPlugin):
                 new_drive_hash = hash(open(driving.__file__, encoding='utf-8').read())
                 new_plan_hash = hash(open(planning.__file__, encoding='utf-8').read())
                 new_im_hash = hash(open(im.__file__, encoding='utf-8').read())
-                new_oh_hash = hash(open(oh.__file__, encoding='utf-8').read())  
+                new_oh_hash = hash(open(oh.__file__, encoding='utf-8').read())
+                new_pred_hash = hash(open(prediction.__file__, encoding='utf-8').read())
                 if new_nav_hash != last_nav_hash:
                     last_nav_hash = new_nav_hash
                     logging.info("Navigation module changed, reloading...")
@@ -178,6 +181,11 @@ class Plugin(ETS2LAPlugin):
                     logging.info("Offset handler module changed, reloading...")
                     importlib.reload(oh)
                     logging.info("Successfully reloaded offset handler module")
+                if new_pred_hash != last_pred_hash:
+                    last_pred_hash = new_pred_hash
+                    logging.info("Prediction module changed, reloading...")
+                    importlib.reload(prediction)
+                    logging.info("Successfully reloaded prediction module")
             except Exception as e:
                 logging.error(f"Error monitoring modules: {e}")
             time.sleep(1)
@@ -308,6 +316,7 @@ class Plugin(ETS2LAPlugin):
                 
                 steering_start_time = time.perf_counter()
                 steering_value = driving.GetSteering()
+                prediction.GetPredictedPath()
 
                 if steering_value is not None:
                     steering_value = steering_value / 180
@@ -365,9 +374,11 @@ class Plugin(ETS2LAPlugin):
                     self.globals.tags.road_type = "normal"
 
                 self.globals.tags.route_information = [item.information_json() for item in data.route_plan]
+                self.globals.tags.predicted_path = [point.tuple() for point in data.prediction_points]
             else:
                 self.globals.tags.next_intersection_distance = 1
                 self.globals.tags.road_type = "none"
+                self.globals.tags.predicted_path = []
         except:
             pass
         external_data_time = time.perf_counter() - external_data_start_time

--- a/Plugins/Map/route/planning.py
+++ b/Plugins/Map/route/planning.py
@@ -41,9 +41,17 @@ def GetRoadsInFrontOfRoad(road: c.Road, include_self:bool = True) -> list[c.Road
     return roads
         
 def PrefabToRouteSection(prefab: c.Prefab, lane_index: int, invert: bool = False) -> rc.RouteSection:
+    """Create a RouteSection from a prefab ensuring the lane index is valid."""
     route_section = rc.RouteSection()
     route_item = rc.RouteItem()
     route_item.item = prefab
+
+    if lane_index < 0 or lane_index >= len(prefab.nav_routes):
+        logging.warning(
+            f"Invalid lane index {lane_index} for prefab {prefab.uid}, clamping"
+        )
+        lane_index = max(0, min(lane_index, len(prefab.nav_routes) - 1))
+
     route_item.lane_index = lane_index
     route_section.items = [route_item]
     route_section.invert = invert
@@ -59,6 +67,7 @@ def PrefabToRouteSection(prefab: c.Prefab, lane_index: int, invert: bool = False
     return route_section
 
 def RoadToRouteSection(road: c.Road, lane_index: int, target_lanes: list[int] = [], invert: bool = False) -> rc.RouteSection:
+    """Create a RouteSection from a road ensuring the lane index is valid."""
     route_section = rc.RouteSection()
     route_section.items = []
     
@@ -80,11 +89,16 @@ def RoadToRouteSection(road: c.Road, lane_index: int, target_lanes: list[int] = 
     for list_road in accepted_roads:
         route_item = rc.RouteItem()
         route_item.item = list_road
+        if lane_index < 0 or lane_index >= len(list_road.lanes):
+            logging.warning(
+                f"Invalid lane index {lane_index} for road {list_road.uid}, clamping"
+            )
+            lane_index = max(0, min(lane_index, len(list_road.lanes) - 1))
         route_item.lane_index = lane_index
         route_section.items.append(route_item)
     
     route_section.invert = invert
-    if (lane_index > len(route_section.items[0].item.lanes) - 1):
+    if lane_index < 0 or lane_index >= len(route_section.items[0].item.lanes):
         return None
     
     route_section.lane_index = lane_index

--- a/Plugins/Map/route/prediction.py
+++ b/Plugins/Map/route/prediction.py
@@ -1,0 +1,34 @@
+import Plugins.Map.utils.math_helpers as math_helpers
+import Plugins.Map.route.driving as driving
+import Plugins.Map.data as data
+import Plugins.Map.classes as c
+
+
+def GetPredictedPath(point_count: int | None = None) -> list[c.Position]:
+    """Generate future path points based on the current route plan."""
+    if point_count is None:
+        point_count = data.prediction_point_count
+
+    if len(data.route_plan) == 0:
+        data.prediction_points = []
+        return []
+
+    points: list[c.Position] = []
+    for section in data.route_plan:
+        if len(points) >= point_count:
+            break
+        if section is None:
+            continue
+        section_points = section.get_points()
+        for point in section_points:
+            if len(points) >= point_count:
+                break
+            if len(points) == 0:
+                points.append(point)
+                continue
+            distance = math_helpers.DistanceBetweenPoints(point.tuple(), points[-1].tuple())
+            if distance >= driving.GetPointDistance(len(points), point_count):
+                if distance <= 20 and point not in points:
+                    points.append(point)
+    data.prediction_points = points
+    return points

--- a/Plugins/Map/ui.py
+++ b/Plugins/Map/ui.py
@@ -106,6 +106,7 @@ class SettingsMenu(ETS2LASettingsMenu):
                                 Space(0)
                                 Description(f"Is steering: {self.get_value_from_data('calculate_steering')}")
                                 Description(f"Route points: {len(self.get_value_from_data('route_points'))}")
+                                Description(f"Prediction points: {len(self.get_value_from_data('prediction_points'))}")
                                 Description(f"Route plan elements: {len(self.get_value_from_data('route_plan'))}")
                                 Description(f"Routing mode: {settings.Get('Map', 'RoutingMode')}")
                                 Description(f"Navigation points: {len(self.get_value_from_data('navigation_points'))}")

--- a/Plugins/VisualizationSockets/main.py
+++ b/Plugins/VisualizationSockets/main.py
@@ -430,6 +430,8 @@ class Plugin(ETS2LAPlugin):
     
     def steering(self, data):
         points = self.plugins.Map
+        prediction = self.globals.tags.predicted_path
+        prediction = self.globals.tags.merge(prediction)
         information = self.globals.tags.route_information
         information = self.globals.tags.merge(information)
         
@@ -439,9 +441,10 @@ class Plugin(ETS2LAPlugin):
         if not points:
             return {
                 "points": [],
+                "prediction": [],
                 "information": information
             }
-        
+
         send = {
             "points": [
                 {
@@ -449,6 +452,13 @@ class Plugin(ETS2LAPlugin):
                     "y": point[1],
                     "z": point[2]
                 } for point in points
+            ],
+            "prediction": [
+                {
+                    "x": point[0],
+                    "y": point[1],
+                    "z": point[2]
+                } for point in prediction
             ],
             "information": information # already a dictionary
         }


### PR DESCRIPTION
## Summary
- add `prediction_point_count` and `prediction_points` to Map data
- new module `prediction.py` computes future path points
- expose prediction points via global tags and VisualizationSockets
- show prediction information in Map debug UI
- reload prediction module when modified
- validate lane indices and clamp when needed
- fix off-by-one checks in predicted path generation

## Testing
- `python -m py_compile Plugins/Map/route/prediction.py Plugins/Map/main.py Plugins/VisualizationSockets/main.py Plugins/Map/ui.py Plugins/Map/route/driving.py Plugins/Map/route/planning.py Plugins/Map/classes.py Plugins/Map/data.py`
